### PR TITLE
Add alternative WASD keyboard controls

### DIFF
--- a/car.js
+++ b/car.js
@@ -1,3 +1,17 @@
+const KEY_CONTROLS_ARROWS = {
+  UP: 38,
+  DOWN: 40,
+  LEFT: 37,
+  RIGHT: 39
+};
+const KEY_CONTROLS_WASD = {
+  UP: 87,
+  DOWN: 83,
+  LEFT: 65,
+  RIGHT: 68
+};
+const keyActive = (key, keysDown) => keysDown[KEY_CONTROLS_ARROWS[key]] || keysDown[KEY_CONTROLS_WASD[key]];
+
 let windowWidth = window.innerWidth;
 let windowHeight = window.innerHeight;
 
@@ -115,12 +129,12 @@ function update () {
       brakingPower -= brakingFactor;
     }
   } else {
-    if (keysDown[38]) {
+    if (keyActive('UP', keysDown)) {
       power += powerFactor;
     } else {
       power -= powerFactor;
     }
-    if (keysDown[40]) {
+    if (keyActive('DOWN', keysDown)) {
       brakingPower += brakingFactor;
     } else {
       brakingPower -= brakingFactor;
@@ -141,10 +155,10 @@ function update () {
         angularVelocity += direction * turnSpeed * touching.right;
       }
     } else {
-      if (keysDown[37]) {
+      if (keyActive('LEFT', keysDown)) {
         angularVelocity -= direction * turnSpeed;
       }
-      if (keysDown[39]) {
+      if (keyActive('RIGHT', keysDown)) {
         angularVelocity += direction * turnSpeed;
       }
     }


### PR DESCRIPTION
This change adds WASD keys controls without affecting arrow controls. So now the car can be controlled with either, or a combination of both, i.e. both WASD and arrows can be used at the same time.

I've added this becuase some people tend to prefer WASD controls and others prefer arrows. This change makes it easy to support both and so it makes it easier for people to appreciate the movement of the car.

It is only a suggestion, though, you don't need to merge it if you don't like it or if you have other ideas about the control scheme. In any case, I've also made it so that the configuration of the keys is separated in one place (the `keyPressed` function) instead of hard coded into the main code, so that it can be changed more easily if you decide to modify it later.