### PR TITLE
Add gamepad support

### DIFF
--- a/car.js
+++ b/car.js
@@ -130,6 +130,35 @@ window.addEventListener('touchstart', e => {
   window.addEventListener('touchend', touchend);
 });
 
+// handle gamepad keys
+let gamepad; // keep track of active gamepad
+const gamepadKeys = {}; // keep track of mapped gamepad keys
+
+// detect when gamepad is connected
+window.addEventListener('gamepadconnected', (e) => {
+  const getGamepadInput = () => {
+    const gamepadIndex = e.gamepad.index;
+    gamepad = navigator.getGamepads()[gamepadIndex];
+
+    // map gamepad keys to game
+    if (gamepad) {
+      // A [xbox] or X [playstation]
+      gamepadKeys.up = gamepad.buttons[0].pressed;
+      // B [xbox] or O [playstation]
+      gamepadKeys.down = gamepad.buttons[1].pressed;
+      // left axes or directional left
+      gamepadKeys.left = gamepad.buttons[14].pressed || gamepad.axes[0] === -1;
+      // right axes or directional right
+      gamepadKeys.right = gamepad.buttons[15].pressed || gamepad.axes[0] === 1;
+    }
+
+    requestAnimationFrame(getGamepadInput);
+  }
+
+  // run getGamePadInput every animation frame handled by browser
+  requestAnimationFrame(getGamepadInput);
+});
+
 function updateCar (car, i) {
   if (car.isThrottling) {
     car.power += powerFactor * car.isThrottling;
@@ -199,8 +228,8 @@ setInterval(() => {
       localCar.isTurningRight = turnRight;
     }
   } else {
-    const pressingUp = keyActive('up');
-    const pressingDown = keyActive('down');
+    const pressingUp = keyActive('up') || gamepadKeys.up;
+    const pressingDown = keyActive('down') || gamepadKeys.down;
 
     if (localCar.isThrottling !== pressingUp || localCar.isReversing !== pressingDown) {
       changed = true;
@@ -208,8 +237,8 @@ setInterval(() => {
       localCar.isReversing = pressingDown;
     }
 
-    const turnLeft = canTurn && keyActive('left');
-    const turnRight = canTurn && keyActive('right');
+    const turnLeft = canTurn && keyActive('left') || canTurn && gamepadKeys.left;
+    const turnRight = canTurn && keyActive('right') || canTurn && gamepadKeys.right;
 
     if (localCar.isTurningLeft !== turnLeft) {
       changed = true;


### PR DESCRIPTION
In this pull request I have added gamepad support to car project by leveraging [gamepad api](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API).

Here are the current gamepad keys mapping:

|       Action        |                                     xbox                                                |                              playstation                                                        |
|---------------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
|   Accelration       | ![A key](https://upload.wikimedia.org/wikipedia/commons/d/d2/Xbox_button_A.svg)         |  ![X key](https://upload.wikimedia.org/wikipedia/commons/8/8f/PlayStation_button_X.svg)         |
|   Backwards         | ![B key](https://upload.wikimedia.org/wikipedia/commons/b/b8/Xbox_button_B.svg)         |  ![O key](https://upload.wikimedia.org/wikipedia/commons/6/6b/PlayStation_button_C.svg)         |
|   Turn Left         | ![Left key](https://upload.wikimedia.org/wikipedia/commons/3/36/Xbox_D-Pad_Left.svg)    |  ![Left key](https://upload.wikimedia.org/wikipedia/commons/4/4b/PlayStation_Left_button.svg)   |
|   Turn Right        | ![Right key](https://upload.wikimedia.org/wikipedia/commons/a/a2/Xbox_D-Pad_Right.svg)  |  ![Right key](https://upload.wikimedia.org/wikipedia/commons/d/de/PlayStation_Right_button.svg) |

> Note that turning left and right also works with moving analog left and right

Let me know if there are any Issues, I haven't tested this with other gamepad controllers so your feedback will be much appreciated.